### PR TITLE
Replaced empty error message when generating owls file from diagram containing unassociated inputs/outputs

### DIFF
--- a/owls/src/owls/wizards/OwlsFileGenerationWizard.java
+++ b/owls/src/owls/wizards/OwlsFileGenerationWizard.java
@@ -6,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     André Fonseca - initial API and implementation
+ *     Andrï¿½ Fonseca - initial API and implementation
  *******************************************************************************/
 
 package owls.wizards;
@@ -75,7 +75,7 @@ public class OwlsFileGenerationWizard extends Wizard implements INewWizard{
 			Throwable realException = e.getTargetException();
 			System.err.println("ERRO ENCONTRADO NA CRIACAO DO CONTAINER - OwlsFileGenerationWizard");
 			e.printStackTrace(System.err);
-			MessageDialog.openError(getShell(), "Error", realException.getMessage());
+			MessageDialog.openError(getShell(), "Error", "One or more connections on the composition have properties which do not have a value set.");
 			return false;
 		}
 		return true;


### PR DESCRIPTION
Before:

![image](https://f.cloud.github.com/assets/2272207/1111238/e3ac7386-19a4-11e3-979c-f0a3cd9caeb0.png)

After:

![image](https://f.cloud.github.com/assets/2272207/1111240/eda1623e-19a4-11e3-9a27-276a1bc196c0.png)
